### PR TITLE
Use validVisualizers instead of visualizers for consistency

### DIFF
--- a/src/visualizers/panels/TreeViz/TreeVizControl.js
+++ b/src/visualizers/panels/TreeViz/TreeVizControl.js
@@ -22,7 +22,7 @@ define([
 
   console.log({ GMETransformations });
   const { TransformationObserver } = GMETransformations;
-  const SET_NAME = "visualizers";
+  const SET_NAME = "validVisualizers";
   const ENGINE_NAME = "TreeViz";
 
   var TreeVizControl;
@@ -100,8 +100,6 @@ define([
   };
 
   TreeVizControl.prototype.selectedObjectChanged = async function (nodeId) {
-    var self = this;
-
     // TODO: get the path of the transformation node
     this._currentNodeId = nodeId;
     this._currentNodeParentId = undefined;


### PR DESCRIPTION
This has been changed for consistency with the registry name in webgme for defining visualizers. Ideally, this code will be merged into webgme and then it won't be implemented at all here but for now, this gets us a little closer to a standard convention.